### PR TITLE
Resolve sh region

### DIFF
--- a/naa-processfindings.py
+++ b/naa-processfindings.py
@@ -203,9 +203,14 @@ def get_local_env():
     split_arn = sts_arn.split(':')
     partition = split_arn[1]
     account = split_arn[4]
+
+    session = boto3.Session()
+    region = session.region_name
+
     local_env = {
         "partition": partition,
-        "account": account
+        "account": account,
+        "region": region
     }
     return local_env
 
@@ -217,7 +222,7 @@ def map_naa_finding_to_sh(finding_details):
     naa_finding.append({
         "SchemaVersion": "2018-10-08",
         "Id": finding_id,
-        "ProductArn": (f"arn:{finding_details['partition']}:securityhub:{finding_details['region']}:{local_env['account']}:product/{local_env['account']}/default"),
+        "ProductArn": (f"arn:{local_env['partition']}:securityhub:{local_env['region']}:{local_env['account']}:product/{local_env['account']}/default"),
         "GeneratorId": "NetworkAccessAnalzyer",
         "AwsAccountId": local_env['account'],
         'ProductFields': {

--- a/naa-resources.yaml
+++ b/naa-resources.yaml
@@ -176,11 +176,6 @@ Resources:
               - "organizations:DescribeOrganization"
             Resource: "*"
           - Effect: Allow
-            Sid: AllowDescribeAZ
-            Action:
-              - "ec2:DescribeAvailabilityZones"
-            Resource: "*"
-          - Effect: Allow
             Sid: AllowImportFindingsToSecHub
             Action:
               - "securityhub:BatchImportFindings"


### PR DESCRIPTION
Resolved an issue where findings discovered in AWS accounts which were NOT local to the AWS Security Hub region, would generate the incorrect SH Schema ProductArn.  This has been corrected by utilizing the region where the Python script making boto3 calls is executing.

In order to update the script local to previous cloned repo versions:

Change to the directory of the cloned code
     cd /usr/local/naa
Stash all local changes (e.g. custom parameters in naa-script.sh)
     git stash
Pull the latest files from the repository
     git pull
Merge the local stashed changes back into the pulled files
     git stash pop